### PR TITLE
Removed 'form-submit' class from lists of links.

### DIFF
--- a/grails-app/views/process/processList/_searchResults.gsp
+++ b/grails-app/views/process/processList/_searchResults.gsp
@@ -56,7 +56,7 @@
           <td><gf:displayDateTime value="${process.finishedOn}"/>&nbsp;${process.finishedBy}
           </td>
           <td class="text-right">
-            <div class="btn-group input-group-btn form-submit text-right">
+            <div class="btn-group input-group-btn text-right">
               <nobr>
               <g:if test="${!process.status.isFinal && (process.status.statusID != com.jcatalog.grailsflow.status.ProcessStatusEnum.KILLING.value())}">
                 <g:link class="btn btn-sm btn-default" onclick="return askConfirmation('${g.message(code: 'plugin.grailsflow.question.confirm')}');" controller="${params['controller']}" action="killProcess" id="${process.id}" title="${g.message(code: 'plugin.grailsflow.command.kill')}"

--- a/grails-app/views/processDef/editTypes.gsp
+++ b/grails-app/views/processDef/editTypes.gsp
@@ -43,7 +43,7 @@
                      <td><g:set var="label" value="${gf.translatedValue(['translations': scripts[item].label, 'default': scripts[item].processType])}" scope="page" />${label?.encodeAsHTML()}</td>
                      <td><g:set var="description" value="${gf.translatedValue(['translations': scripts[item].description, 'default': ''])}" scope="page" />${description?.encodeAsHTML()}</td>
                      <td>
-                       <div class="btn-group input-group-btn form-submit text-right">
+                       <div class="btn-group input-group-btn text-right">
                          <nobr>
                            <g:link action="editProcessDef" controller="${params['controller']}" id="${scripts[item].processType}" title="${g.message(code: 'plugin.grailsflow.command.edit')}"  class="btn btn-sm btn-default">
                              <span class="glyphicon glyphicon-edit"></span>&nbsp;

--- a/grails-app/views/schedulerDetails/showSchedulerDetails.gsp
+++ b/grails-app/views/schedulerDetails/showSchedulerDetails.gsp
@@ -162,7 +162,7 @@
                       <g:message code="plugin.grailsflow.label.running"/>
                     </g:if>
                     <g:else>
-                      <div class="btn-group input-group-btn form-submit text-right">
+                      <div class="btn-group input-group-btn text-right">
                         <nobr>
                           <g:link class="btn btn-sm btn-default" controller="${params['controller']}" action="pause"
                                   params="${[name: jobInfo?.job?.name, group: jobInfo?.job?.group, isPaused: jobInfo?.paused ? jobInfo?.paused : 'false', isRunning: jobInfo?.running ? jobInfo.running : 'false']}"


### PR DESCRIPTION
Removed 'form-submit' class from lists of links on 'searchResult', 'editTypes' and 'showSchedulerDetails' pages.