### PR TITLE
Add package for services

### DIFF
--- a/grails-app/services/com/jcatalog/grailsflow/GenerateProcessService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/GenerateProcessService.groovy
@@ -1,3 +1,4 @@
+package com.jcatalog.grailsflow
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/com/jcatalog/grailsflow/GrailsflowLockService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/GrailsflowLockService.groovy
@@ -1,3 +1,5 @@
+package com.jcatalog.grailsflow
+
 import com.jcatalog.grailsflow.model.process.ProcessNode
 import com.jcatalog.grailsflow.cluster.GrailsflowLock
 import com.jcatalog.grailsflow.utils.ConstantUtils

--- a/grails-app/services/com/jcatalog/grailsflow/GrailsflowMessageBundleService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/GrailsflowMessageBundleService.groovy
@@ -1,3 +1,4 @@
+package com.jcatalog.grailsflow
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/com/jcatalog/grailsflow/ProcessAdministrationService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/ProcessAdministrationService.groovy
@@ -1,3 +1,5 @@
+package com.jcatalog.grailsflow
+
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import groovy.transform.Synchronized

--- a/grails-app/services/com/jcatalog/grailsflow/ProcessExporterService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/ProcessExporterService.groovy
@@ -1,3 +1,4 @@
+package com.jcatalog.grailsflow
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/com/jcatalog/grailsflow/ProcessManagerService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/ProcessManagerService.groovy
@@ -1,3 +1,4 @@
+package com.jcatalog.grailsflow
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/com/jcatalog/grailsflow/ProcessProtocolingService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/ProcessProtocolingService.groovy
@@ -1,3 +1,4 @@
+package com.jcatalog.grailsflow
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/com/jcatalog/grailsflow/ProcessWorklistService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/ProcessWorklistService.groovy
@@ -1,3 +1,4 @@
+package com.jcatalog.grailsflow
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/grails-app/services/com/jcatalog/grailsflow/SchedulerOperationsService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/SchedulerOperationsService.groovy
@@ -1,3 +1,5 @@
+package com.jcatalog.grailsflow
+
 import org.quartz.SchedulerException
 import org.quartz.Trigger
 import java.text.DateFormat

--- a/grails-app/services/com/jcatalog/grailsflow/ThreadRuntimeInfoService.groovy
+++ b/grails-app/services/com/jcatalog/grailsflow/ThreadRuntimeInfoService.groovy
@@ -1,3 +1,5 @@
+package com.jcatalog.grailsflow
+
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import com.jcatalog.grailsflow.engine.concurrent.ProcessNotifier


### PR DESCRIPTION
To inherit from grailsflow service classes in other grails plugins we need some package for this classes. It makes possible to compile plugin wich contains child of grailsflow service separately.