### PR TITLE
Render correct JSON strings

### DIFF
--- a/grails-app/views/processDef/showGraphic.gsp
+++ b/grails-app/views/processDef/showGraphic.gsp
@@ -87,8 +87,8 @@
 
      var obj
      var port, port2
-     var transitionsData = evalJson('${transitionsJson}')
-     var positions = evalJson('${positions}')
+     var transitionsData = evalJson('${raw(transitionsJson)}')
+     var positions = evalJson('${raw(positions)}')
      var nodes = new Array(positions.length)
 
      function openNodeEditor(nodeID) {


### PR DESCRIPTION
Render correct JSON strings when

grails.views.default.codec = "html"

is set in Config.groovy which is default for grails 2.3 and later