### PR TITLE
Always use css/js in the plugin

### DIFF
--- a/grails-app/conf/GrailsflowResources.groovy
+++ b/grails-app/conf/GrailsflowResources.groovy
@@ -21,54 +21,54 @@ modules = {
     }
     grailsflow {
         dependsOn 'jquery'
-        resource url:'/js/grailsflow/common.js'
-        resource url: '/js/grailsflow/jquery/config.js'
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/common.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/jquery/config.js']
     }
     grailsflowGraphics {
         dependsOn 'jquery'
-        resource url:'/css/grailsflow/graphic/ext-all.css'
-        resource url:'/js/grailsflow/common.js'
-        resource url:'/js/grailsflow/draw2d/draw2d.js'
-        resource url:'/js/grailsflow/draw2d/wz_jsgraphics.js'
-        resource url:'/js/grailsflow/draw2d/YahooUI_integration/adapter/yui/yui-utilities.js'
-        resource url:'/js/grailsflow/draw2d/YahooUI_integration/adapter/yui/ext-yui-adapter.js'
-        resource url:'/js/grailsflow/draw2d/YahooUI_integration/ext-all.js'
-        resource url:'/js/grailsflow/draw2d/node/NodeFigure.js'
-        resource url:'/js/grailsflow/draw2d/node/ContextmenuConnection.js'
-        resource url:'/js/grailsflow/draw2d/node/NodeInputPort.js'
-        resource url:'/js/grailsflow/draw2d/node/NodeOutputPort.js'
-        resource url:'/js/grailsflow/draw2d/node/TransitionDecorator.js'
+        resource url: [plugin: 'grailsflow', file: 'css/grailsflow/graphic/ext-all.css']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/common.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/draw2d.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/wz_jsgraphics.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/YahooUI_integration/adapter/yui/yui-utilities.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/YahooUI_integration/adapter/yui/ext-yui-adapter.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/YahooUI_integration/ext-all.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/node/NodeFigure.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/node/ContextmenuConnection.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/node/NodeInputPort.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/node/NodeOutputPort.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/draw2d/node/TransitionDecorator.js']
     }
 
     grailsflowDatepicker {
         dependsOn('jquery')
-        resource url: '/css/grailsflow/datepicker/bootstrap-datepicker.min.css'
-        resource url: '/js/grailsflow/datepicker/bootstrap-datepicker.min.js'
-        resource url: '/js/grailsflow/datepicker/bootstrap-datepicker.de.min.js'
-        resource url: '/js/grailsflow/datepicker/bootstrap-datepicker.es.min.js'
+        resource url: [plugin: 'grailsflow', file: 'css/grailsflow/datepicker/bootstrap-datepicker.min.css'], nominify: true
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/datepicker/bootstrap-datepicker.min.js'], nominify: true
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/datepicker/bootstrap-datepicker.de.min.js'], nominify: true
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/datepicker/bootstrap-datepicker.es.min.js'], nominify: true
     }
 
     grailsflowJgplot {
         dependsOn 'jquery'
-        resource url:'/css/grailsflow/jqplot/jquery.jqplot.min.css'
-        resource url:'/js/grailsflow/jqplot/excanvas.min.js', wrapper: {s -> "<!--[if IE]>$s<![endif]-->"}, disposition: 'head'
-        resource url:'/js/grailsflow/jqplot/jquery.jqplot.min.js'
-        resource url:'/js/grailsflow/jqplot/plugins/jqplot.categoryAxisRenderer.min.js'
-        resource url:'/js/grailsflow/jqplot/plugins/jqplot.enhancedLegendRenderer.min.js'
+        resource url: [plugin: 'grailsflow', file: 'css/grailsflow/jqplot/jquery.jqplot.min.css'], nominify: true
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/jqplot/excanvas.min.js'], nominify: true, wrapper: {s -> "<!--[if IE]>$s<![endif]-->"}, disposition: 'head'
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/jqplot/jquery.jqplot.min.js'], nominify: true
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/jqplot/plugins/jqplot.categoryAxisRenderer.min.js'], nominify: true
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/jqplot/plugins/jqplot.enhancedLegendRenderer.min.js'], nominify: true
 
     }
     grailsflowCodeMirror {
-        resource url:'/css/grailsflow/codemirror/codemirror.css'
-        resource url:'/css/grailsflow/codemirror/default.css'
-        resource url:'/js/grailsflow/codemirror/codemirror.js'
-        resource url:'/js/grailsflow/codemirror/clike.js'
-        resource url:'/css/grailsflow/codemirror/grailsflow.css'
+        resource url: [plugin: 'grailsflow', file: 'css/grailsflow/codemirror/codemirror.css']
+        resource url: [plugin: 'grailsflow', file: 'css/grailsflow/codemirror/default.css']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/codemirror/codemirror.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/codemirror/clike.js']
+        resource url: [plugin: 'grailsflow', file: 'css/grailsflow/codemirror/grailsflow.css']
     }
     grailsflowHighlighter {
-        resource url:'/css/grailsflow/syntaxhighlighter/shCore.css'
-        resource url:'/css/grailsflow/syntaxhighlighter/shThemeDefault.css'
-        resource url:'/js/grailsflow/syntaxhighlighter/shCore.js'
-        resource url:'/js/grailsflow/syntaxhighlighter/shBrushGroovy.js'
+        resource url: [plugin: 'grailsflow', file: 'css/grailsflow/syntaxhighlighter/shCore.css']
+        resource url: [plugin: 'grailsflow', file: 'css/grailsflow/syntaxhighlighter/shThemeDefault.css']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/syntaxhighlighter/shCore.js']
+        resource url: [plugin: 'grailsflow', file: 'js/grailsflow/syntaxhighlighter/shBrushGroovy.js']
     }
 
 }


### PR DESCRIPTION
When we override GSP pages in the project, the resources can't be found since they are not in project level directory.

This change make grails generate resource url with plugin path.