### PR TITLE
Node assignees should be read from database

### DIFF
--- a/grails-app/controllers/ProcessManagementController.groovy
+++ b/grails-app/controllers/ProcessManagementController.groovy
@@ -225,7 +225,13 @@ class ProcessManagementController extends GrailsFlowSecureController {
         // checking process node assignees and user authorities
         def authorities = getUserAuthorities(session)
 
-        def nodeAssignees = processClass.nodes[nodeID]?.assignees?.collect() { it.assigneeID.trim() }
+        def nodeAssignees = []
+        node?.process?.assignees?.each {
+            if (it.nodeID == nodeID) nodeAssignees << it.assigneeID.trim()
+        }
+        if (nodeAssignees.isEmpty()) {
+            nodeAssignees = processClass.nodes[nodeID]?.assignees?.collect() { it.assigneeID.trim() }
+        }
         if (nodeAssignees && !nodeAssignees.isEmpty() && nodeAssignees.intersect(authorities).isEmpty()) {
             flash.errors << g.message(code: "plugin.grailsflow.message.nodeAuthorities.invalid")
             withFormat {


### PR DESCRIPTION
Since node assignees can be changed dynamically, when checking permission of current node, the allowed assignees list should be read from database instead of static process class.